### PR TITLE
allow separate master and management nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,16 @@ Example config.yaml
 depl:
   installer_image: my-private-registry.com/ibmcom/icp-inception:3.2.2
   nodes: 3 # optional, how many nodes to dedicate to the cloud pak. Default: 3
-
+  
+### Alternatively you can split out master and management 
+### nodes by specifying how many nodes of each type
+# depl:
+#   installer_image: my-private-registry.com/ibmcom/icp-inception:3.2.2
+#   nodes: 
+#     master: 3 
+#     management: 3
+  
+  
 ## The rest is the normal config.yaml passed into the inception installer
 
 #### NOTE 


### PR DESCRIPTION
Currently there's some configuration drift with the BoD environment (as well as any other larger implementation) requiring separate nodes for master and management.

This enhancement allows specifying numbers of master and management nodes separately, like this:
```
depl:
  nodes: 
    master: 3 
    management: 3
```
which will in a 3 AZ cluster dedicate 1 worker in each AZ for master, and 1 worker in each AZ for management.
